### PR TITLE
Update flow test branch to support page object documents out of the box

### DIFF
--- a/test/flow_test_helper.rb
+++ b/test/flow_test_helper.rb
@@ -5,6 +5,7 @@ require 'capybara/rails'
 require 'capybara/dsl'
 require 'ae_page_objects'
 require 'ae_page_objects/rails'
+require 'page_objects/document'
 
 module PageObjects
 end


### PR DESCRIPTION
This PR updates the `flow_test_helper` to require page_objects/document. This fixes an issue several Ropes people ran into while refactoring their flow tests, and is more of a hiccup than a learning experience.