### PR TITLE
jm - remove lists before installing firefox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
       - run:
           name: Install the latest firefox
           command: |
+            sudo rm -rf /var/lib/apt/lists/* &&
             sudo sh -c "echo 'deb http://ftp.hr.debian.org/debian sid main' >> /etc/apt/sources.list" &&
             sudo apt-get update &&
             sudo apt-get install -t sid firefox &&


### PR DESCRIPTION
For some reason the existing circleCI config was running into an error installing firefox. You can see it even on the base project here https://app.circleci.com/pipelines/github/AppFolioOnboarding/base/jobs/56
This fixes that