### PR TITLE
update firefox install flags for Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             sudo rm -rf /var/lib/apt/lists/* &&
             sudo sh -c "echo 'deb http://ftp.hr.debian.org/debian sid main' >> /etc/apt/sources.list" &&
             sudo apt-get update &&
-            sudo apt-get install -t sid firefox &&
+            sudo apt-get install -t sid -o APT::Immediate-Configure=0 firefox &&
             firefox --version
 
       # Download and cache dependencies


### PR DESCRIPTION
Circle CI was experiencing build failures during the firefox
installation step. The failure occurs when attempting to
perform immediate configuration on 'libcrypt1:amd64'. Disabling
immediate configuration in the install command allows the build to
succeed.

Confirmed build failure using existing config on master: https://app.circleci.com/pipelines/github/AppFolioOnboarding/base/5/workflows/8edc0bf5-6af4-4a9b-97a8-24a0e36e6e9e/jobs/64